### PR TITLE
Canvas Renderer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-empty-function": "off",
-    "@typescript-eslint/no-unused-vars": "off"
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/ban-ts-comment": "off"
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ All data sent over the websocket is in binary format as an optimisation (eg avoi
 
 Two websocket tunnels are available for use: the standard websocket or a socket.io websocket. Since data is sent in binary format the standard websocket is recommended rather than socket.io for better performance. 
 
-WebGL is used to render the Remote Desktop (using the three.js library): textures for individual X11 windows and generated and updated directly from JPEG data sent from WebX Engine running the WebX host. 
+WebGL is used primarily to render the Remote Desktop (using the three.js library): textures for individual X11 windows and generated and updated directly from JPEG data sent from WebX Engine running the WebX host.
+
+If WebGL is not available on the browser (or if software rendering is used) then the client library uses a custom CanvasRender to render the window images to pure HTML Canvases. In this case window image blending is performed in a web worker. 
 
 To account for varying bandwidths between the client and the remote desktop, the client can request different quality settings. For lower quality, this will for example reduce the image quality and reduce the frequency of window updates.
 

--- a/src/WebXClient.ts
+++ b/src/WebXClient.ts
@@ -350,19 +350,7 @@ export class WebXClient {
    * @returns A promise that resolves to image data in Blob form.
    */
   async createScreenshot(type: string, quality: number): Promise<Blob> {
-    return new Promise<Blob>((resolve, reject) => {
-      try {
-        this.display.render();
-        console.log('Creating Screenshot not implemented');
-        resolve(null);
-        // this.display.renderer.domElement.toBlob((blob: Blob) => {
-        //   resolve(blob);
-        // }, type, quality)
-
-      } catch (error) {
-        reject(error);
-      }
-    })
+    return this.display.createScreenshot(type, quality);
   }
 
   /**

--- a/src/WebXClient.ts
+++ b/src/WebXClient.ts
@@ -353,9 +353,11 @@ export class WebXClient {
     return new Promise<Blob>((resolve, reject) => {
       try {
         this.display.render();
-        this.display.renderer.domElement.toBlob((blob: Blob) => {
-          resolve(blob);
-        }, type, quality)
+        console.log('Creating Screenshot not implemented');
+        resolve(null);
+        // this.display.renderer.domElement.toBlob((blob: Blob) => {
+        //   resolve(blob);
+        // }, type, quality)
 
       } catch (error) {
         reject(error);

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -7,6 +7,7 @@ import { WebXCursor } from './WebXCursor';
 import { WebXTextureFactory } from './WebXTextureFactory';
 import { WebXCursorFactory } from './WebXCursorFactory';
 import {WebXCanvasRenderer} from '../renderer';
+import {Blob} from "buffer";
 
 type WebGLInfo = {
   available: boolean;
@@ -251,6 +252,31 @@ export class WebXDisplay {
    */
   render(): void {
     this._renderer.render(this._scene, this._camera);
+  }
+
+  /**
+   * Creates a screenshot of the current desktop with the specified image type and quality
+   * @param type The type of the screenshot (e.g., 'image/png').
+   * @param quality The quality of the screenshot (0 to 1).
+   */
+  async createScreenshot(type: string, quality: number): Promise<Blob> {
+    if (this._renderer instanceof WebXCanvasRenderer) {
+      return this._renderer.createScreenshot(type, quality);
+
+    } else {
+      const renderer = this._renderer as THREE.WebGLRenderer;
+      return new Promise<Blob>((resolve, reject) => {
+        try {
+          this.render();
+          renderer.domElement.toBlob((blob: Blob) => {
+            resolve(blob);
+          }, type, quality)
+
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }
   }
 
   /**

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -156,8 +156,8 @@ export class WebXDisplay {
     this._camera.position.z = 1000;
     this._camera.lookAt(new Vector3(0, 0, 0));
 
-    const webglInfo = this._detectWebGL();
-    console.log(`WebGL Info: available = ${webglInfo.available}, isSoftware = ${webglInfo.isSoftware}, vendor = ${webglInfo.vendor}, renderer = ${webglInfo.renderer}`);
+    const webglInfo = this._detectWebGL2();
+    console.log(`WebGL2 Info: available = ${webglInfo.available}, isSoftware = ${webglInfo.isSoftware}, vendor = ${webglInfo.vendor}, renderer = ${webglInfo.renderer}`);
 
     const url = new URL(window.location.href);
     const params = url.searchParams;
@@ -167,7 +167,12 @@ export class WebXDisplay {
       this._renderer = new THREE.WebGLRenderer();
 
     } else {
-      console.log(`Falling back to Canvas Renderer`);
+      if (forceCanvas) {
+        console.log(`Canvas Renderer enabled through request param`);
+
+      } else {
+        console.log(`Falling back to Canvas Renderer`);
+      }
       this._renderer = new WebXCanvasRenderer();
     }
 
@@ -527,7 +532,7 @@ export class WebXDisplay {
   /**
    * Returns details about the availability and type of WebGL2 rendering
    */
-  private _detectWebGL(): WebGLInfo {
+  private _detectWebGL2(): WebGLInfo {
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl2");
     if (!gl) {
@@ -546,9 +551,8 @@ export class WebXDisplay {
     }
 
     const rendererStr = (unmaskedRenderer || renderer || "").toLowerCase();
-
     const isSoftware = /swiftshader|llvmpipe|basic render|software/i.test(rendererStr);
 
-    return { available: true, vendor: unmaskedRenderer || vendor, renderer: unmaskedVendor || renderer, isSoftware };
+    return { available: true, vendor: unmaskedVendor || vendor, renderer: unmaskedRenderer || renderer, isSoftware };
   }
 }

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -6,6 +6,7 @@ import { WebXSubImage } from './WebXSubImage';
 import { WebXCursor } from './WebXCursor';
 import { WebXTextureFactory } from './WebXTextureFactory';
 import { WebXCursorFactory } from './WebXCursorFactory';
+import {WebXCanvasRenderer} from "../renderer";
 
 /**
  * Manages the rendering of the WebX remote desktop using WebGL.
@@ -18,7 +19,7 @@ export class WebXDisplay {
 
   private readonly _scene: THREE.Scene;
   private readonly _camera: THREE.OrthographicCamera;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: THREE.WebGLRenderer | WebXCanvasRenderer;
   private readonly _screen: THREE.Object3D;
 
   private readonly _screenWidth: number;
@@ -47,7 +48,7 @@ export class WebXDisplay {
    *
    * @returns The WebGLRenderer instance.
    */
-  public get renderer(): THREE.WebGLRenderer {
+  public get renderer(): THREE.WebGLRenderer | WebXCanvasRenderer {
     return this._renderer;
   }
 
@@ -149,7 +150,8 @@ export class WebXDisplay {
     this._camera.position.z = 1000;
     this._camera.lookAt(new Vector3(0, 0, 0));
 
-    this._renderer = new THREE.WebGLRenderer();
+    // this._renderer = new THREE.WebGLRenderer();
+    this._renderer = new WebXCanvasRenderer();
     this._renderer.setSize(screenWidth, screenHeight, false);
 
     const backgroundColor = window.getComputedStyle(this._containerElement).backgroundColor;

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -6,7 +6,7 @@ import { WebXSubImage } from './WebXSubImage';
 import { WebXCursor } from './WebXCursor';
 import { WebXTextureFactory } from './WebXTextureFactory';
 import { WebXCursorFactory } from './WebXCursorFactory';
-import {WebXCanvasRenderer} from "../renderer";
+import {WebXCanvasRenderer} from '../renderer';
 
 /**
  * Manages the rendering of the WebX remote desktop using WebGL.
@@ -236,7 +236,7 @@ export class WebXDisplay {
    */
   addWindow(window: WebXWindow): void {
     if (this._windows.find(existingWindow => existingWindow.id === window.id) == null) {
-      // console.log("Adding window ", window.id)
+      // console.log('Adding window ', window.id)
       this._windows.push(window);
       this._screen.add(window.mesh);
       this._sceneDirty = true;
@@ -250,7 +250,7 @@ export class WebXDisplay {
    */
   removeWindow(window: WebXWindow): void {
     if (this._windows.find(existingWindow => existingWindow.id === window.id) != null) {
-      // console.log("Removing window ", window.id)
+      // console.log('Removing window ', window.id)
       this._windows = this._windows.filter(existingWindow => existingWindow.id !== window.id);
       window.dispose();
       this._screen.remove(window.mesh);

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -358,12 +358,18 @@ export class WebXDisplay {
       const alphaMap = window.alphaMap;
       for(let i= 0; i< subImages.length; i++) {
         const subImage = subImages[i];
-        if (colorMap && subImage.colorMap) {
-          this._renderer.copyTextureToTexture(subImage.colorMap, colorMap, null, new THREE.Vector2(subImage.x, subImage.y));
+        if (this._renderer instanceof WebXCanvasRenderer) {
+          this._renderer.updateWindowRegion(window.mesh.id, subImage.colorMap, colorMap, subImage.alphaMap, alphaMap, subImage.width, subImage.height, new THREE.Vector2(subImage.x, subImage.y));
+
+        } else {
+          if (colorMap && subImage.colorMap) {
+            this._renderer.copyTextureToTexture(subImage.colorMap, colorMap, null, new THREE.Vector2(subImage.x, subImage.y));
+          }
+          if (alphaMap && subImage.alphaMap) {
+            this._renderer.copyTextureToTexture(subImage.alphaMap, alphaMap, null, new THREE.Vector2(subImage.x, subImage.y));
+          }
         }
-        if (alphaMap && subImage.alphaMap) {
-          this._renderer.copyTextureToTexture(subImage.alphaMap, alphaMap, null, new THREE.Vector2(subImage.x, subImage.y));
-        }
+
       }
       window.updateTexture(window.depth, colorMap, alphaMap, false);
       this._sceneDirty = true;

--- a/src/display/WebXDisplay.ts
+++ b/src/display/WebXDisplay.ts
@@ -158,7 +158,6 @@ export class WebXDisplay {
     this._camera.lookAt(new Vector3(0, 0, 0));
 
     const webglInfo = this._detectWebGL2();
-    console.log(`WebGL2 Info: available = ${webglInfo.available}, isSoftware = ${webglInfo.isSoftware}, vendor = ${webglInfo.vendor}, renderer = ${webglInfo.renderer}`);
 
     const url = new URL(window.location.href);
     const params = url.searchParams;
@@ -168,6 +167,7 @@ export class WebXDisplay {
       this._renderer = new THREE.WebGLRenderer();
 
     } else {
+      console.log(`WebGL2 Info: available = ${webglInfo.available}, isSoftware = ${webglInfo.isSoftware}, vendor = ${webglInfo.vendor}, renderer = ${webglInfo.renderer}`);
       if (forceCanvas) {
         console.log(`Canvas Renderer enabled through request param`);
 

--- a/src/renderer/WebXAlphaBlender.ts
+++ b/src/renderer/WebXAlphaBlender.ts
@@ -21,7 +21,7 @@ export class WebXAlphaBlender {
 
   constructor() {
     if (typeof Worker !== "undefined") {
-      console.log("Web Workers are available");
+      // console.log("Web Workers are available");
       const blob = new Blob(["(", alphaWorkerFunc.toString(), ")()"], { type: "application/javascript" });
       const blobUrl = URL.createObjectURL(blob);
       this._worker = new Worker(blobUrl);
@@ -41,7 +41,7 @@ export class WebXAlphaBlender {
       };
 
     } else {
-      console.log("Web Workers are NOT available");
+      // console.log("Web Workers are NOT available");
     }
   }
 

--- a/src/renderer/WebXAlphaBlender.ts
+++ b/src/renderer/WebXAlphaBlender.ts
@@ -1,0 +1,78 @@
+function alphaWorkerFunc() {
+  self.onmessage = (e) => {
+    const { id, colorBuffer, alphaBuffer, width, height } = e.data;
+    const colorData = new Uint8ClampedArray(colorBuffer);
+    const alphaData = new Uint8ClampedArray(alphaBuffer);
+
+    // Blend alpha (green channel -> alpha)
+    for (let i = 0; i < colorData.length; i += 4) {
+      colorData[i + 3] = alphaData[i + 1];
+    }
+
+    // @ts-ignore
+    self.postMessage({ id, colorBuffer: colorData.buffer, width, height }, [colorData.buffer]);
+  };
+}
+
+export class WebXAlphaBlender {
+  private _worker: Worker;
+  private _pending = new Map<number, (imageData: ImageData) => void>();
+  private _nextId = 1;
+
+  constructor() {
+    if (typeof Worker !== "undefined") {
+      console.log("Web Workers are available");
+      const blob = new Blob(["(", alphaWorkerFunc.toString(), ")()"], { type: "application/javascript" });
+      const blobUrl = URL.createObjectURL(blob);
+      this._worker = new Worker(blobUrl);
+      URL.revokeObjectURL(blobUrl);
+
+      this._worker.onmessage = (e) => {
+        const { id, colorBuffer, width, height } = e.data;
+        const callback = this._pending.get(id);
+        if (!callback) return;
+        this._pending.delete(id);
+
+        // Recreate ImageData from transferred buffer
+        const blendedData = new Uint8ClampedArray(colorBuffer);
+        const blendedImageData = new ImageData(blendedData, width, height);
+
+        callback(blendedImageData);
+      };
+
+    } else {
+      console.log("Web Workers are NOT available");
+    }
+  }
+
+  public async blendAlpha(colorImageData: ImageData, alphaImageData: ImageData): Promise<ImageData> {
+    return new Promise((resolve) => {
+      if (this._worker) {
+        const id = this._nextId++;
+        this._pending.set(id, resolve);
+
+        this._worker.postMessage(
+          {
+            id,
+            colorBuffer: colorImageData.data.buffer,
+            alphaBuffer: alphaImageData.data.buffer,
+            width: colorImageData.width,
+            height: colorImageData.height,
+          },
+          [colorImageData.data.buffer, alphaImageData.data.buffer]
+        );
+
+      } else {
+        for (let i = 0; i < colorImageData.data.length; i += 4) {
+          colorImageData.data[i + 3] = alphaImageData.data[i + 1];
+        }
+        resolve(colorImageData);
+      }
+    });
+  }
+
+  public terminate() {
+    this._worker.terminate();
+    this._pending.clear();
+  }
+}

--- a/src/renderer/WebXAlphaStencilBlender.ts
+++ b/src/renderer/WebXAlphaStencilBlender.ts
@@ -35,7 +35,7 @@ function alphaWorkerFunc() {
   };
 }
 
-export class WebXAlphaBlender {
+export class WebXAlphaStencilBlender {
   private readonly _worker: Worker;
   private _pending = new Map<number, (imageData: ImageData) => void>();
   private _nextId = 1;

--- a/src/renderer/WebXAlphaStencilBlender.ts
+++ b/src/renderer/WebXAlphaStencilBlender.ts
@@ -1,5 +1,11 @@
+/**
+ * The Alpha and stencil buffer blending function. The alpha buffer contains alpha data in the
+ * green channel. The stencil buffer is a black and white image: only pixels with a stencil value > 127 are to be rendered
+ * @param colorData the color data array
+ * @param alphaData the alpha data array
+ * @param stencilData the stencil data array
+ */
 function alphaAndStencilBlend(colorData, alphaData, stencilData) {
-  // Blend alpha (green channel -> alpha)
   if (alphaData && stencilData) {
     for (let i = 0; i < colorData.length; i += 4) {
       if (stencilData[i] < 128) {
@@ -9,6 +15,7 @@ function alphaAndStencilBlend(colorData, alphaData, stencilData) {
         colorData[i + 3] = alphaData[i + 1];
       }
     }
+
   } else if (alphaData) {
     for (let i = 0; i < colorData.length; i += 4) {
       colorData[i + 3] = alphaData[i + 1];
@@ -21,6 +28,10 @@ function alphaAndStencilBlend(colorData, alphaData, stencilData) {
   }
 }
 
+/**
+ * The entry point for the web worker. Receives messages with data for color, alpha and stencil data and calls the blending
+ * function.
+ */
 function alphaWorkerFunc() {
   self.onmessage = (e) => {
     const { id, colorBuffer, alphaBuffer, stencilBuffer, width, height } = e.data;
@@ -35,11 +46,21 @@ function alphaWorkerFunc() {
   };
 }
 
+/**
+ * The `WebXAlphaStencilBlender` class handles blending of alpha and stencil data
+ * for rendering purposes. It uses a Web Worker for asynchronous processing.
+ */
 export class WebXAlphaStencilBlender {
   private readonly _worker: Worker;
   private _pending = new Map<number, (imageData: ImageData) => void>();
   private _nextId = 1;
 
+  /**
+   * Initializes the `WebXAlphaStencilBlender` and sets up the Web Worker (if web-workers present on the client).
+   * The web worker is initialised from the worker/blending functions above. Each blending request is assigned an id.
+   * The data is passed to the web worker along with the Id. The web worker returns the Id with blended data so that the
+   * calling promise can be resolved.
+   */
   constructor() {
     if (typeof Worker !== 'undefined') {
       const blob = new Blob([alphaAndStencilBlend.toString(), '(', alphaWorkerFunc.toString(), ')()'], { type: 'application/javascript' });
@@ -62,6 +83,15 @@ export class WebXAlphaStencilBlender {
     }
   }
 
+  /**
+   * Blends alpha and stencil data asynchronously.
+   * Main entry point to blend the different buffers. If a web-worker is available on the client then the data is prepared to transfer
+   * to the worker. Otherwise the standard blending function is called immediately.
+   * @param colorImageData - The color image data.
+   * @param alphaImageData - The alpha image data.
+   * @param stencilImageData - The stencil image data.
+   * @returns A promise that resolves to the blended `ImageData`.
+   */
   public async blendAlphaAndStencil(colorImageData: ImageData, alphaImageData: ImageData, stencilImageData: ImageData): Promise<ImageData> {
     return new Promise((resolve) => {
       if (this._worker) {
@@ -98,6 +128,9 @@ export class WebXAlphaStencilBlender {
     });
   }
 
+  /**
+   * Terminates the Web Worker and clears pending tasks.
+   */
   public terminate() {
     this._worker.terminate();
     this._pending.clear();

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -1,13 +1,13 @@
 import {Camera, Color, ColorRepresentation, Mesh, Object3D, Texture, Vector2} from 'three';
 import {WebXWindowCanvas} from './WebXWindowCanvas';
-import {WebXAlphaBlender} from './WebXAlphaBlender';
+import {WebXAlphaStencilBlender} from './WebXAlphaStencilBlender';
 
 export class WebXCanvasRenderer {
 
   private _desktopContainer: HTMLElement;
   private _desktop: HTMLElement;
   private _clearColor: Color = new Color( 0, 0, 0);
-  private readonly _alphaBlender: WebXAlphaBlender;
+  private readonly _alphaStencilBlender: WebXAlphaStencilBlender;
 
   private _windowCanvases: Map<number, WebXWindowCanvas> = new Map();
 
@@ -17,7 +17,7 @@ export class WebXCanvasRenderer {
 
   constructor() {
     this.createMainElement();
-    this._alphaBlender = new WebXAlphaBlender();
+    this._alphaStencilBlender = new WebXAlphaStencilBlender();
   }
 
   public setSize(width: number, height: number, unused?: boolean) {
@@ -72,7 +72,7 @@ export class WebXCanvasRenderer {
       this.removeWindowCanvas(windowCanvas)
     }
 
-    this._alphaBlender.terminate();
+    this._alphaStencilBlender.terminate();
   }
 
   public updateWindowRegion(meshId: number, srcColorMap: Texture, dstColorMap: Texture, srcAlphaMap: Texture, dstAlphaMap: Texture, width: number, height: number, dstPosition: Vector2) {
@@ -100,7 +100,7 @@ export class WebXCanvasRenderer {
   }
 
   private createWindowCanvas(mesh: Mesh) {
-    const windowCanvas = new WebXWindowCanvas(mesh, this._alphaBlender);
+    const windowCanvas = new WebXWindowCanvas(mesh, this._alphaStencilBlender);
     this._desktop.appendChild(windowCanvas.element);
     this._windowCanvases.set(mesh.id, windowCanvas);
   }

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -1,0 +1,120 @@
+import {Box2, Camera, Color, ColorRepresentation, Object3D, Texture, Vector2} from "three";
+import {WebXColorGenerator} from "../utils";
+
+export class WebXCanvasRenderer {
+
+  private _desktopContainer: HTMLElement;
+  private _desktop: HTMLElement;
+  private _clearColor: Color = new Color( 0, 0, 0);
+
+  private _windowElements: Map<number, HTMLElement> = new Map();
+
+  get domElement(): HTMLElement {
+    return this._desktopContainer;
+  }
+
+  constructor() {
+    this.createMainElement();
+  }
+
+  public setSize(width: number, height: number, unused?: boolean) {
+    this._desktop.style.width = `${width}px`;
+    this._desktop.style.height = `${height}px`;
+  }
+
+  public setClearColor(color: ColorRepresentation) {
+    this._clearColor.set(color);
+    this._desktop.style.backgroundColor = `#${this._clearColor.getHexString()}`;
+  }
+
+  public render(scene: Object3D, camera: Camera) {
+    // Check if the screen has been added to the scene
+    if (scene.children.length > 0) {
+      const screen = scene.children[0];
+
+      const activeWindowIds = new Set();
+
+      // Update visible windows
+      for (const windowObject of screen.children) {
+        if (!this._windowElements.has(windowObject.id)) {
+          this.createWindowElement(windowObject);
+        }
+        const windowElement = this._windowElements.get(windowObject.id);
+        this.updateGeometry(windowElement, windowObject);
+
+        activeWindowIds.add(windowObject.id);
+      }
+
+      // Remove defunct windows
+      for (const [windowId, element] of this._windowElements.entries()) {
+        if (!activeWindowIds.has(windowId)) {
+          this.removeWindowElement(windowId, element)
+        }
+      }
+
+    } else if (this._windowElements.size > 0) {
+      // Remove all windows
+      for (const [windowId, element] of this._windowElements.entries()) {
+        this.removeWindowElement(windowId, element)
+      }
+    }
+  }
+
+  public dispose() {
+
+  }
+
+  public copyTextureToTexture(src: Texture, dst: Texture, srcRegion?: Box2 | null, dstPosition?: Vector2 | null) {
+
+  }
+
+  private createMainElement() {
+    const desktopContainer = this.createElementNS('div');
+    desktopContainer.id = 'webx-desktop-container';
+    desktopContainer.style.display = 'block';
+    desktopContainer.style.position = 'relative';
+    desktopContainer.style.overflow = 'hidden';
+
+    const desktop = document.createElement('div');
+    desktop.id = 'webx-desktop';
+    desktopContainer.style.position = 'absolute';
+    desktopContainer.style.transformOrigin = 'top left';
+    desktopContainer.appendChild(desktop);
+
+    this._desktopContainer = desktopContainer;
+    this._desktop = desktop;
+  }
+
+  private createWindowElement(object: Object3D) {
+    const windowElement = this.createElementNS('div');
+    windowElement.id = `webx-window-${object.id}`;
+    windowElement.style.position = 'absolute';
+    windowElement.style.backgroundColor = WebXColorGenerator.indexedColour(object.id);
+    windowElement.style.pointerEvents = 'none';
+
+    this.updateGeometry(windowElement, object);
+
+    this._desktop.appendChild(windowElement);
+
+    this._windowElements.set(object.id, windowElement);
+  }
+
+  private removeWindowElement(windowId: number, windowElement: HTMLElement) {
+    this._desktop.removeChild(windowElement);
+    this._windowElements.delete(windowId);
+  }
+
+  private updateGeometry(element: HTMLElement, object: Object3D) {
+    const x = object.position.x - 0.5 * object.scale.x;
+    const y = object.position.y - 0.5 * object.scale.y;
+    element.style.top = `${y}px`;
+    element.style.left = `${x}px`;
+    element.style.width = `${object.scale.x}px`;
+    element.style.height = `${object.scale.y}px`;
+    element.style.zIndex = `${object.position.z}`;
+  }
+
+  private createElementNS(name: string): HTMLElement {
+    return document.createElementNS('http://www.w3.org/1999/xhtml', name);
+  }
+}

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -70,7 +70,7 @@ export class WebXCanvasRenderer {
   public copyTextureToTexture(src: Texture, dst: Texture, srcRegion?: Box2 | null, dstPosition?: Vector2 | null) {
     Array.from(this._windowCanvases.values()).forEach(windowCanvas => {
       if (windowCanvas.colorMap === dst || windowCanvas.alphaMap === dst) {
-        windowCanvas.updateCanvasRegion(src, dst, srcRegion, dstPosition);
+        windowCanvas.updateCanvasRegion(src, dst, dstPosition);
       }
     });
   }

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -68,7 +68,11 @@ export class WebXCanvasRenderer {
   }
 
   public copyTextureToTexture(src: Texture, dst: Texture, srcRegion?: Box2 | null, dstPosition?: Vector2 | null) {
-
+    Array.from(this._windowCanvases.values()).forEach(windowCanvas => {
+      if (windowCanvas.colorMap === dst || windowCanvas.alphaMap === dst) {
+        windowCanvas.updateCanvasRegion(src, dst, srcRegion, dstPosition);
+      }
+    });
   }
 
   private createMainElement() {

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -1,6 +1,6 @@
-import {Box2, Camera, Color, ColorRepresentation, Mesh, Object3D, Texture, Vector2} from "three";
-import {WebXWindowCanvas} from "./WebXWindowCanvas";
-import {WebXAlphaBlender} from "./WebXAlphaBlender";
+import {Camera, Color, ColorRepresentation, Mesh, Object3D, Texture, Vector2} from 'three';
+import {WebXWindowCanvas} from './WebXWindowCanvas';
+import {WebXAlphaBlender} from './WebXAlphaBlender';
 
 export class WebXCanvasRenderer {
 

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -64,13 +64,19 @@ export class WebXCanvasRenderer {
   }
 
   public dispose() {
-
+    // Remove all windows
+    for (const [_, windowCanvas] of this._windowCanvases.entries()) {
+      this.removeWindowCanvas(windowCanvas)
+    }
   }
 
   public copyTextureToTexture(src: Texture, dst: Texture, srcRegion?: Box2 | null, dstPosition?: Vector2 | null) {
     Array.from(this._windowCanvases.values()).forEach(windowCanvas => {
-      if (windowCanvas.colorMap === dst || windowCanvas.alphaMap === dst) {
-        windowCanvas.updateCanvasRegion(src, dst, dstPosition);
+      if (windowCanvas.colorMap === dst) {
+        windowCanvas.updateColorRegion(src, dstPosition);
+
+      } else if (windowCanvas.alphaMap === dst) {
+        windowCanvas.updateAlphaRegion(src, dstPosition);
       }
     });
   }

--- a/src/renderer/WebXCanvasRenderer.ts
+++ b/src/renderer/WebXCanvasRenderer.ts
@@ -2,42 +2,69 @@ import {Camera, Color, ColorRepresentation, Mesh, Object3D, Texture, Vector2} fr
 import {WebXWindowCanvas} from './WebXWindowCanvas';
 import {WebXAlphaStencilBlender} from './WebXAlphaStencilBlender';
 
+/**
+ * The `WebXCanvasRenderer` class is responsible for rendering a desktop-like environment
+ * using HTML elements. It integrates with the Three.js library using 3D objects (meshes, materials, textures)
+ * to hold the graphical data used to render the windows.
+ */
 export class WebXCanvasRenderer {
 
   private _desktopContainer: HTMLElement;
   private _desktop: HTMLElement;
-  private _clearColor: Color = new Color( 0, 0, 0);
+  private _clearColor: Color = new Color(0, 0, 0);
   private readonly _alphaStencilBlender: WebXAlphaStencilBlender;
 
   private _windowCanvases: Map<number, WebXWindowCanvas> = new Map();
 
+  /**
+   * Gets the root DOM element of the renderer.
+   * @returns The root DOM element.
+   */
   get domElement(): HTMLElement {
     return this._desktopContainer;
   }
 
+  /**
+   * Initializes the `WebXCanvasRenderer` by creating the main desktop container
+   * and initializing the alpha stencil blender.
+   */
   constructor() {
     this.createMainElement();
     this._alphaStencilBlender = new WebXAlphaStencilBlender();
   }
 
+  /**
+   * Sets the size of the desktop container.
+   * @param width - The width of the desktop in pixels.
+   * @param height - The height of the desktop in pixels.
+   * @param unused - An optional unused parameter.
+   */
   public setSize(width: number, height: number, unused?: boolean) {
     this._desktop.style.width = `${width}px`;
     this._desktop.style.height = `${height}px`;
   }
 
+  /**
+   * Sets the background color of the desktop.
+   * @param color - The color to set, represented as a `ColorRepresentation`.
+   */
   public setClearColor(color: ColorRepresentation) {
     this._clearColor.set(color);
     this._desktop.style.backgroundColor = `#${this._clearColor.getHexString()}`;
   }
 
+  /**
+   * Renders the scene: updates the window element positions, sizes and z-orders and updates
+   * the graphical content of the windows. Any windows that are no longer in the scene have their
+   * graphical elements removed from the dom.
+   * @param scene - The root `Object3D` containing the scene to render.
+   * @param camera - The `Camera` used for rendering (currently unused).
+   */
   public render(scene: Object3D, camera: Camera) {
-    // Check if the screen has been added to the scene
     if (scene.children.length > 0) {
       const screen = scene.children[0];
-
       const activeWindowIds = new Set();
 
-      // Update visible windows
       for (const object of screen.children) {
         if (object instanceof Mesh && object.visible) {
           if (!this._windowCanvases.has(object.id)) {
@@ -54,27 +81,44 @@ export class WebXCanvasRenderer {
       // Remove defunct windows
       for (const [windowId, windowCanvas] of this._windowCanvases.entries()) {
         if (!activeWindowIds.has(windowId)) {
-          this.removeWindowCanvas(windowCanvas)
+          this.removeWindowCanvas(windowCanvas);
         }
       }
 
     } else if (this._windowCanvases.size > 0) {
       // Remove all windows
       for (const [_, windowCanvas] of this._windowCanvases.entries()) {
-        this.removeWindowCanvas(windowCanvas)
+        this.removeWindowCanvas(windowCanvas);
       }
     }
   }
 
+  /**
+   * Disposes of the renderer by removing all window canvases and terminating
+   * the alpha stencil blender (and its web worker if present).
+   */
   public dispose() {
     // Remove all windows
     for (const [_, windowCanvas] of this._windowCanvases.entries()) {
-      this.removeWindowCanvas(windowCanvas)
+      this.removeWindowCanvas(windowCanvas);
     }
 
+    // Terminate the blended web worker if present
     this._alphaStencilBlender.terminate();
   }
 
+  /**
+   * Updates a specific region of a window canvas from the color and alpha data sent from the server. The updates are stored in the window
+   * and handled at the next render request.
+   * @param meshId - The ID of the mesh associated with the window canvas.
+   * @param srcColorMap - The source color texture.
+   * @param dstColorMap - The destination color texture.
+   * @param srcAlphaMap - The source alpha texture.
+   * @param dstAlphaMap - The destination alpha texture.
+   * @param width - The width of the region to update.
+   * @param height - The height of the region to update.
+   * @param dstPosition - The destination position of the region.
+   */
   public updateWindowRegion(meshId: number, srcColorMap: Texture, dstColorMap: Texture, srcAlphaMap: Texture, dstAlphaMap: Texture, width: number, height: number, dstPosition: Vector2) {
     const windowCanvas = this._windowCanvases.get(meshId);
     if (windowCanvas) {
@@ -82,6 +126,9 @@ export class WebXCanvasRenderer {
     }
   }
 
+  /**
+   * Creates the main desktop container element and initializes its styles.
+   */
   private createMainElement() {
     const desktopContainer = this.createElementNS('div');
     desktopContainer.id = 'webx-desktop-container';
@@ -99,17 +146,30 @@ export class WebXCanvasRenderer {
     this._desktop = desktop;
   }
 
+  /**
+   * Creates a new window canvas for the given mesh and adds it to the desktop.
+   * @param mesh - The `Mesh` object representing the window.
+   */
   private createWindowCanvas(mesh: Mesh) {
     const windowCanvas = new WebXWindowCanvas(mesh, this._alphaStencilBlender);
     this._desktop.appendChild(windowCanvas.element);
     this._windowCanvases.set(mesh.id, windowCanvas);
   }
 
+  /**
+   * Removes a window canvas from the desktop and cleans up its resources.
+   * @param windowCanvas - The `WebXWindowCanvas` to remove.
+   */
   private removeWindowCanvas(windowCanvas: WebXWindowCanvas) {
     this._desktop.removeChild(windowCanvas.element);
     this._windowCanvases.delete(windowCanvas.id);
   }
 
+  /**
+   * Creates an HTML element with the specified namespace.
+   * @param name - The name of the element to create.
+   * @returns The created `HTMLElement`.
+   */
   private createElementNS(name: string): HTMLElement {
     return document.createElementNS('http://www.w3.org/1999/xhtml', name);
   }

--- a/src/renderer/WebXWindowCanvas.ts
+++ b/src/renderer/WebXWindowCanvas.ts
@@ -1,6 +1,6 @@
 import {Material, Mesh, MeshBasicMaterial, Texture, Vector2} from "three";
 import {WebXMaterial} from "../display/WebXMaterial";
-import {WebXAlphaBlender} from "./WebXAlphaBlender";
+import {WebXAlphaStencilBlender} from "./WebXAlphaStencilBlender";
 
 type RegionUpdate = {
   srcColorMap: Texture;
@@ -42,7 +42,7 @@ export class WebXWindowCanvas {
   }
 
   constructor(private readonly _mesh: Mesh,
-              private readonly _alphaBlender: WebXAlphaBlender) {
+              private readonly _alphaStencilBlender: WebXAlphaStencilBlender) {
     this._element = this.createElementNS('div');
     this._element.id = `webx-window-${this.id}`;
     this._element.style.position = 'absolute';
@@ -247,7 +247,7 @@ export class WebXWindowCanvas {
     if (this._stencilContext) {
       stencilImageData = this._stencilContext.getImageData(dstX, dstY, width, height);
     }
-    const blendedImageData = await this._alphaBlender.blendAlphaAndStencil(colorImageData, alphaImageData, stencilImageData);
+    const blendedImageData = await this._alphaStencilBlender.blendAlphaAndStencil(colorImageData, alphaImageData, stencilImageData);
 
     const endTime = performance.now();
     // console.log(`Time to blend alpha image = ${(endTime - startTime).toFixed((3))}ms for ${width * height} pixels`);

--- a/src/renderer/WebXWindowCanvas.ts
+++ b/src/renderer/WebXWindowCanvas.ts
@@ -1,5 +1,4 @@
-import {WebXColorGenerator} from "../utils";
-import {Mesh, MeshBasicMaterial, Texture} from "three";
+import {Box2, Mesh, MeshBasicMaterial, Texture, Vector2} from "three";
 import {WebXMaterial} from "../display/WebXMaterial";
 
 export class WebXWindowCanvas {
@@ -10,6 +9,8 @@ export class WebXWindowCanvas {
 
   private _colorMap: Texture;
   private _colorMapVersion: number = 0;
+  private _alphaMap: Texture;
+  private _alphaMapVersion: number = 0;
 
   get id(): number {
     return this._mesh.id;
@@ -17,6 +18,14 @@ export class WebXWindowCanvas {
 
   get element(): HTMLElement {
     return this._element;
+  }
+
+  get colorMap(): Texture {
+    return this._colorMap;
+  }
+
+  get alphaMap(): Texture {
+    return this._alphaMap;
   }
 
   constructor(private readonly _mesh: Mesh) {
@@ -78,6 +87,19 @@ export class WebXWindowCanvas {
         }
       }
 
+    }
+  }
+
+  public updateCanvasRegion(src: Texture, dst: Texture, srcRegion?: Box2 | null, dstPosition?: Vector2 | null) {
+    if (this._colorMap === dst) {
+      const image = src.image;
+      const dstX = dstPosition ? dstPosition.x : 0;
+      const dstY = dstPosition ? dstPosition.y : 0;
+      const srcX = srcRegion ? srcRegion.min.x : 0;
+      const srcY = srcRegion ? srcRegion.min.y : 0;
+      const srcWidth = srcRegion ? srcRegion.max.x - srcRegion.min.x : image.width;
+      const srcHeight = srcRegion ? srcRegion.max.y - srcRegion.min.y : image.height;
+      this._context.drawImage(image, srcX, srcY, srcWidth, srcHeight, dstX, dstY, srcWidth, srcHeight)  ;
     }
   }
 

--- a/src/renderer/WebXWindowCanvas.ts
+++ b/src/renderer/WebXWindowCanvas.ts
@@ -62,13 +62,9 @@ export class WebXWindowCanvas {
       const material = this._mesh.material as WebXMaterial | MeshBasicMaterial;
 
       if (material.map) {
-        if (material.map != this._colorMap || material.alphaMap != this._alphaMap) {
-          const colorImage = material.map.image;
-          const alphaImage = material.alphaMap
-            ? material.alphaMap.image.width == colorImage.width && material.alphaMap.image.height == colorImage.height
-              ? material.alphaMap.image
-              : null
-            : null;
+        const colorImage = material.map.image;
+
+        if (material.map != this._colorMap) {
 
           const width = colorImage.width;
           const height = colorImage.height;
@@ -79,9 +75,14 @@ export class WebXWindowCanvas {
           this._canvas.style.height = `${height}px`;
           this._context.drawImage(colorImage, 0, 0, width, height);
 
+          this._colorMap = material.map;
+        }
+
+        if (material.alphaMap != this._alphaMap && this.isValidAlphaMap(material.alphaMap)) {
+          const alphaImage = material.alphaMap.image;
+
           this.blendAlpha(alphaImage, 0, 0);
 
-          this._colorMap = material.map;
           this._alphaMap = material.alphaMap;
         }
 
@@ -112,7 +113,16 @@ export class WebXWindowCanvas {
     }
   }
 
-  private blendAlpha(alphaImage: any, offsetX: number, offsetY: number) {
+  private isValidAlphaMap(alphaMap: Texture): boolean {
+    if (alphaMap) {
+      const width = alphaMap.image.width;
+      const height = alphaMap.image.height;
+      return width === this._canvas.width && height === this._canvas.height;
+    }
+    return false;
+  }
+
+  private blendAlpha(alphaImage: ImageBitmap, offsetX: number, offsetY: number) {
     if (!alphaImage) {
       return;
     }

--- a/src/renderer/WebXWindowCanvas.ts
+++ b/src/renderer/WebXWindowCanvas.ts
@@ -1,4 +1,4 @@
-import {Material, Mesh, MeshBasicMaterial, Texture, Vector2} from "three";
+import {Mesh, MeshBasicMaterial, Texture, Vector2} from "three";
 import {WebXMaterial} from "../display/WebXMaterial";
 import {WebXAlphaStencilBlender} from "./WebXAlphaStencilBlender";
 
@@ -14,12 +14,11 @@ type RegionUpdate = {
 
 /**
  * The `WebXWindowCanvas` class holds the graphical elements necessary for rendering
- * a specific window in the desktop environment. HTML Canvases are used for rendeding image data. Window image data
+ * a specific window in the desktop environment. HTML Canvases are used for rendering image data. Window image data
  * is received in the form of color, alpha and stencil buffers. These are blended to produce the final window image.
  */
 export class WebXWindowCanvas {
 
-  private readonly _element: HTMLElement;
   private readonly _canvas: HTMLCanvasElement;
   private _context: CanvasRenderingContext2D;
 
@@ -46,10 +45,45 @@ export class WebXWindowCanvas {
   }
 
   /**
-   * Gets the root HTML element of the window canvas.
+   * Returns the window canvas
    */
-  get element(): HTMLElement {
-    return this._element;
+  get canvas(): HTMLCanvasElement {
+    return this._canvas;
+  }
+
+  /**
+   * Returns the left-hand x coordinate of the window
+   */
+  get x(): number {
+    return this._x;
+  }
+
+  /**
+   * Returns the top y coordinate of the window
+   */
+  get y(): number {
+    return this._y;
+  }
+
+  /**
+   * Returns the zIndex of the window
+   */
+  get zIndex(): number {
+    return this._zIndex;
+  }
+
+  /**
+   * Returns the width of the window
+   */
+  get width(): number {
+    return this._width;
+  }
+
+  /**
+   * Returns the height of the window
+   */
+  get height(): number {
+    return this._height;
   }
 
   /**
@@ -60,19 +94,13 @@ export class WebXWindowCanvas {
    */
   constructor(private readonly _mesh: Mesh,
               private readonly _alphaStencilBlender: WebXAlphaStencilBlender) {
-    this._element = this.createElementNS('div');
-    this._element.id = `webx-window-${this.id}`;
-    this._element.style.position = 'absolute';
-    this._element.style.pointerEvents = 'none';
-    this._element.style.overflow = 'hidden';
-
     this._canvas = this.createElementNS('canvas') as HTMLCanvasElement;
+    this._canvas.id = `webx-window-${this.id}`;
     this._canvas.style.position = 'absolute';
     this._canvas.style.pointerEvents = 'none';
     this._canvas.style.top = '0';
     this._canvas.style.left = '0';
-
-    this._element.appendChild(this._canvas);
+    this._canvas.style.overflow = 'hidden';
 
     this._context = this._canvas.getContext('2d');
 
@@ -91,22 +119,22 @@ export class WebXWindowCanvas {
     const zIndex = this._mesh.position.z;
 
     if (x !== this._x || y !== this._y) {
-      this._element.style.top = `${y}px`;
-      this._element.style.left = `${x}px`;
+      this._canvas.style.top = `${y}px`;
+      this._canvas.style.left = `${x}px`;
       this._x = x;
       this._y = y;
     }
 
     if (width !== this._width || height !== this._height) {
-      this._element.style.width = `${width}px`;
-      this._element.style.height = `${height}px`;
+      this._canvas.style.width = `${width}px`;
+      this._canvas.style.height = `${height}px`;
 
       this._width = width;
       this._height = height;
     }
 
     if (zIndex !== this._zIndex) {
-      this._element.style.zIndex = `${this._mesh.position.z}`;
+      this._canvas.style.zIndex = `${this._mesh.position.z}`;
       this._zIndex = zIndex;
     }
   }

--- a/src/renderer/WebXWindowCanvas.ts
+++ b/src/renderer/WebXWindowCanvas.ts
@@ -1,0 +1,87 @@
+import {WebXColorGenerator} from "../utils";
+import {Mesh, MeshBasicMaterial, Texture} from "three";
+import {WebXMaterial} from "../display/WebXMaterial";
+
+export class WebXWindowCanvas {
+
+  private readonly _element: HTMLElement;
+  private readonly _canvas: HTMLCanvasElement;
+  private _context: CanvasRenderingContext2D;
+
+  private _colorMap: Texture;
+  private _colorMapVersion: number = 0;
+
+  get id(): number {
+    return this._mesh.id;
+  }
+
+  get element(): HTMLElement {
+    return this._element;
+  }
+
+  constructor(private readonly _mesh: Mesh) {
+    this._element = this.createElementNS('div');
+    this._element.id = `webx-window-${this.id}`;
+    this._element.style.position = 'absolute';
+    // this._element.style.backgroundColor = WebXColorGenerator.indexedColour(this.id);
+    this._element.style.backgroundColor = '#000000';
+    this._element.style.pointerEvents = 'none';
+    this._element.style.overflow = 'hidden';
+
+    this._canvas = this.createElementNS('canvas') as HTMLCanvasElement;
+    this._canvas.style.position = 'absolute';
+    this._canvas.style.pointerEvents = 'none';
+    this._canvas.style.top = '0';
+    this._canvas.style.left = '0';
+
+    this._element.appendChild(this._canvas);
+
+    this._context = this._canvas.getContext("2d");
+
+    this.updateGeometry();
+    this.updateCanvas();
+  }
+
+  public updateGeometry() {
+    const x = this._mesh.position.x - 0.5 * this._mesh.scale.x;
+    const y = this._mesh.position.y - 0.5 * this._mesh.scale.y;
+    this._element.style.top = `${y}px`;
+    this._element.style.left = `${x}px`;
+    this._element.style.width = `${this._mesh.scale.x}px`;
+    this._element.style.height = `${this._mesh.scale.y}px`;
+    this._element.style.zIndex = `${this._mesh.position.z}`;
+  }
+
+  public updateCanvas() {
+    if (this._mesh.material instanceof WebXMaterial || this._mesh.material instanceof MeshBasicMaterial) {
+      const material = this._mesh.material as WebXMaterial | MeshBasicMaterial;
+
+      if (material.map) {
+        if (material.map != this._colorMap || material.map.version != this._colorMapVersion) {
+          const image = material.map.image;
+          this._canvas.width = image.width;
+          this._canvas.height = image.height;
+          this._canvas.style.width = `${image.width}px`;
+          this._canvas.style.height = `${image.height}px`;
+
+          this._context.drawImage(image, 0, 0, image.width, image.height);
+
+          this._colorMap = material.map;
+          this._colorMapVersion = material.map.version;
+        }
+
+      } else {
+        if (this._colorMap) {
+          this._colorMap = null;
+          this._colorMapVersion = 0;
+          this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+        }
+      }
+
+    }
+  }
+
+  private createElementNS(name: string): HTMLElement {
+    return document.createElementNS('http://www.w3.org/1999/xhtml', name);
+  }
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,1 +1,4 @@
 export * from './WebXCanvasRenderer'
+export * from './WebXWindowCanvas'
+export * from './WebXAlphaBlender'
+

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,4 @@
 export * from './WebXCanvasRenderer'
 export * from './WebXWindowCanvas'
-export * from './WebXAlphaBlender'
+export * from './WebXAlphaStencilBlender'
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,0 +1,1 @@
+export * from './WebXCanvasRenderer'


### PR DESCRIPTION
Use HTML canvases to render individual windows. WebWorker used to blend image data from color, alpha and stencil maps. WebXDisplay detects WebGL capabilities during initialisation and fallsback to Canvas Renderer when WebGL is not available or uses software rendering.